### PR TITLE
SecurityUtil.bindSystemStreamsToSLF4J(Logger,Logger) added

### DIFF
--- a/owasp-security-logging-common/src/main/java/org/owasp/security/logging/util/SecurityUtil.java
+++ b/owasp-security-logging-common/src/main/java/org/owasp/security/logging/util/SecurityUtil.java
@@ -7,7 +7,6 @@ import java.util.Properties;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.slf4j.event.Level;
 
 /**
  * Various logging features to consider adding to your own programs.

--- a/owasp-security-logging-common/src/main/java/org/owasp/security/logging/util/SecurityUtil.java
+++ b/owasp-security-logging-common/src/main/java/org/owasp/security/logging/util/SecurityUtil.java
@@ -7,6 +7,7 @@ import java.util.Properties;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.slf4j.event.Level;
 
 /**
  * Various logging features to consider adding to your own programs.
@@ -37,6 +38,23 @@ public class SecurityUtil {
 	    // Enable autoflush
 	    System.setOut(new PrintStream(new OutputStreamRedirector(sysOutLogger, false), true));
 	    System.setErr(new PrintStream(new OutputStreamRedirector(sysErrLogger, true), true));
+	}
+	
+	/**
+	 * Redirect <code>System.out</code> and <code>System.err</code> streams to the given SLF4J loggers.
+	 * This is a benefit if you have a legacy console logger application.  Does not provide
+	 * benefit of a full implementation.  For example, no hierarchical or logger inheritence
+	 * support but there are some ancilarity benefits like, 1) capturing messages that would
+	 * otherwise be lost, 2) redirecting console messages to centralized log services, 3)
+	 * formatting console messages in other types of output (e.g., HTML).
+	 * 
+	 * @param sysOutLogger
+	 * @param sysErrLogger
+	 */
+	public static void bindSystemStreamsToSLF4J(Logger sysOutLogger, Logger sysErrLogger) {
+		SecurityUtil.sysOutLogger = sysOutLogger;
+		SecurityUtil.sysErrLogger = sysErrLogger;
+		bindSystemStreamsToSLF4J();
 	}
 	
 	/**

--- a/owasp-security-logging-logback/src/test/java/org/owasp/security/logging/util/StreamRedirectionWithCustomLoggersTest.java
+++ b/owasp-security-logging-logback/src/test/java/org/owasp/security/logging/util/StreamRedirectionWithCustomLoggersTest.java
@@ -1,0 +1,37 @@
+package org.owasp.security.logging.util;
+
+import static org.mockito.Mockito.*;
+
+import org.junit.Test;
+import org.slf4j.Logger;
+
+/**
+ * @author Jens Piegsa
+ *
+ */
+public class StreamRedirectionWithCustomLoggersTest {
+
+	@Test
+	public void doTest() {
+
+		System.out.println("message 1");
+		System.err.println("message 2");
+
+		final Logger sysOutLogger = spy(Logger.class);
+		final Logger sysErrLogger = spy(Logger.class);
+
+		SecurityUtil.bindSystemStreamsToSLF4J(sysOutLogger, sysErrLogger);
+
+		System.out.println("message 3");
+		System.err.println("message 4");
+
+		SecurityUtil.unbindSystemStreams();
+
+		System.out.println("message 5");
+		System.err.println("message 6");
+
+		verify(sysOutLogger, only()).info("message 3");
+		verify(sysErrLogger, only()).error("message 4");
+	}
+
+}


### PR DESCRIPTION
* allows to configure the redirection output logging independently from
all other log messages produced by SecurityUtil
* `StreamRedirectionWithCustomLoggersTest` added
* this commit fixes #16 