### PR TITLE
Move method to replace CRLF in Utils class

### DIFF
--- a/owasp-security-logging-common/pom.xml
+++ b/owasp-security-logging-common/pom.xml
@@ -40,5 +40,10 @@
       <artifactId>javax.servlet-api</artifactId>
       <scope>provided</scope>
     </dependency>
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 </project>

--- a/owasp-security-logging-common/src/main/java/org/owasp/security/logging/Utils.java
+++ b/owasp-security-logging-common/src/main/java/org/owasp/security/logging/Utils.java
@@ -72,4 +72,15 @@ public class Utils {
 		return (value == null || value.trim().length() == 0);
 	}
 
+	/**
+	 * Replace any carriage returns and line feeds with an underscore to prevent log injection attacks.
+	 *
+	 * @param value
+	 *            string to convert
+	 * @return converted string
+	 */
+	public static String replaceCRLFWithUnderscore(String value) {
+		return value.replace('\n', '_').replace('\r', '_');
+	}
+
 }

--- a/owasp-security-logging-common/src/test/java/org/owasp/security/logging/UtilsTest.java
+++ b/owasp-security-logging-common/src/test/java/org/owasp/security/logging/UtilsTest.java
@@ -1,0 +1,23 @@
+package org.owasp.security.logging;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class UtilsTest {
+
+    @Test
+    public void shouldReplaceCRWithUnderscore() {
+        Assert.assertEquals("hello_world", Utils.replaceCRLFWithUnderscore("hello\rworld"));
+    }
+
+    @Test
+    public void shouldReplaceLFWithUnderscore() {
+        Assert.assertEquals("hello_world", Utils.replaceCRLFWithUnderscore("hello\nworld"));
+    }
+
+    @Test
+    public void shouldReplaceCRLFWithUnderscore() {
+        Assert.assertEquals("hello__world", Utils.replaceCRLFWithUnderscore("hello\r\nworld"));
+    }
+
+}

--- a/owasp-security-logging-logback/src/main/java/org/owasp/security/logging/mask/CRLFConverter.java
+++ b/owasp-security-logging-logback/src/main/java/org/owasp/security/logging/mask/CRLFConverter.java
@@ -2,6 +2,7 @@ package org.owasp.security.logging.mask;
 
 import ch.qos.logback.classic.spi.ILoggingEvent;
 import ch.qos.logback.core.pattern.CompositeConverter;
+import org.owasp.security.logging.Utils;
 
 /**
  * This converter is used to encode any carriage returns and line feeds to
@@ -17,9 +18,7 @@ public class CRLFConverter extends CompositeConverter<ILoggingEvent> {
 
 	@Override
 	protected String transform(ILoggingEvent event, String in) {
-		String clean = in.replace('\n', '_').replace('\r', '_');
-
-		return clean;
+		return Utils.replaceCRLFWithUnderscore(in);
 	}
 
 	/**


### PR DESCRIPTION
I thought the method to replace CRLF and prevent log forging is useful for all logging frameworks so I moved it from logback module to common.