### PR TITLE
Issue #52: add CRLF converter for exception messages

### DIFF
--- a/owasp-security-logging-logback/src/main/java/org/owasp/security/logging/mask/CRLFThrowableConverter.java
+++ b/owasp-security-logging-logback/src/main/java/org/owasp/security/logging/mask/CRLFThrowableConverter.java
@@ -1,0 +1,19 @@
+package org.owasp.security.logging.mask;
+
+import ch.qos.logback.classic.pattern.ThrowableProxyConverter;
+import ch.qos.logback.classic.spi.IThrowableProxy;
+
+/**
+ * This converter is used to encode any carriage returns and line feeds to
+ * prevent log injection attacks in exception messages
+ *
+ * This converter uses a CRLFThrowableProxy that acts as a proxy to intercept
+ * calls to IThrowable.getMessage to replace the characters in the message
+ */
+public class CRLFThrowableConverter extends ThrowableProxyConverter {
+
+    @Override
+    protected String throwableProxyToString(IThrowableProxy tp) {
+        return super.throwableProxyToString(new CRLFThrowableProxy(tp));
+    }
+}

--- a/owasp-security-logging-logback/src/main/java/org/owasp/security/logging/mask/CRLFThrowableProxy.java
+++ b/owasp-security-logging-logback/src/main/java/org/owasp/security/logging/mask/CRLFThrowableProxy.java
@@ -1,0 +1,59 @@
+package org.owasp.security.logging.mask;
+
+import ch.qos.logback.classic.spi.IThrowableProxy;
+import ch.qos.logback.classic.spi.StackTraceElementProxy;
+import org.owasp.security.logging.Utils;
+
+/**
+ * Throwable proxy that replaces CR/LF chars in the message to avoid log injection
+ * in exception messages.
+ * Calls to getMessage are intercepted to replace CR & LF in the message
+ * Calls to getCause are intercepted to ensure all exceptions in the stack are treated
+ * All other other methods are directly sent through the proxied instance.
+ */
+public class CRLFThrowableProxy implements IThrowableProxy {
+    private final IThrowableProxy proxied;
+
+    public CRLFThrowableProxy(IThrowableProxy proxied) {
+        this.proxied = proxied;
+    }
+
+    @Override
+    public String getMessage() {
+        if (proxied.getMessage() == null) {
+            return null;
+        }
+        return Utils.replaceCRLFWithUnderscore(proxied.getMessage());
+    }
+
+    @Override
+    public IThrowableProxy getCause() {
+        if (proxied.getCause() == null) {
+            return null;
+        }
+        if (proxied.getCause() == proxied || proxied.getCause() == this) {
+            return this;
+        }
+        return new CRLFThrowableProxy(proxied.getCause());
+    }
+
+    @Override
+    public String getClassName() {
+        return proxied.getClassName();
+    }
+
+    @Override
+    public StackTraceElementProxy[] getStackTraceElementProxyArray() {
+        return proxied.getStackTraceElementProxyArray();
+    }
+
+    @Override
+    public int getCommonFrames() {
+        return proxied.getCommonFrames();
+    }
+
+    @Override
+    public IThrowableProxy[] getSuppressed() {
+        return proxied.getSuppressed();
+    }
+}

--- a/owasp-security-logging-logback/src/test/java/org/owasp/security/logging/mask/CRLFThrowableConverterTest.java
+++ b/owasp-security-logging-logback/src/test/java/org/owasp/security/logging/mask/CRLFThrowableConverterTest.java
@@ -1,0 +1,135 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.owasp.security.logging.mask;
+
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.LoggerContext;
+import ch.qos.logback.classic.PatternLayout;
+import ch.qos.logback.classic.encoder.PatternLayoutEncoder;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.classic.spi.LoggingEvent;
+import ch.qos.logback.core.rolling.RollingFileAppender;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+import org.slf4j.LoggerFactory;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.verify;
+import static org.slf4j.Logger.ROOT_LOGGER_NAME;
+
+/**
+ *
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class CRLFThrowableConverterTest {
+
+	private LoggerContext loggerContext = (LoggerContext) LoggerFactory
+			.getILoggerFactory();
+
+	private Logger LOGGER;
+
+	private PatternLayoutEncoder encoder;
+
+	private PatternLayout layout;
+
+	@Mock
+	private RollingFileAppender<ILoggingEvent> mockAppender = new RollingFileAppender<>();
+
+	@Captor
+	private ArgumentCaptor<LoggingEvent> captorLoggingEvent;
+
+	@Before
+	public void setUp() {
+		PatternLayout.defaultConverterMap.put("ex",
+				CRLFThrowableConverter.class.getName());
+
+		encoder = new PatternLayoutEncoder();
+		encoder.setContext(loggerContext);
+		encoder.setPattern("%-4relative [%thread] %-5level %logger{35} - %msg %ex%n");
+		encoder.start();
+
+		mockAppender.setContext(loggerContext);
+		mockAppender.setEncoder(encoder);
+		mockAppender.start();
+
+		LOGGER = (Logger) LoggerFactory.getLogger(ROOT_LOGGER_NAME);
+		LOGGER.addAppender(mockAppender);
+	}
+
+	@After
+	public void tearDown() {
+		LOGGER.detachAppender(mockAppender);
+	}
+
+	@Test
+	public void test_with_1_exception() {
+		try {
+			throw new IllegalArgumentException("This message contains \r\n line feeds");
+		} catch (IllegalArgumentException ex) {
+			LOGGER.error("", ex);
+		}
+
+		// Now verify our logging interactions
+		verify(mockAppender).doAppend(captorLoggingEvent.capture());
+
+		// Get the logging event from the captor
+		final LoggingEvent loggingEvent = captorLoggingEvent.getValue();
+
+		// Check log level is correct
+		assertThat(loggingEvent.getLevel(), is(Level.ERROR));
+
+		// Check the message being logged is correct
+		String layoutMessage = encoder.getLayout().doLayout(loggingEvent);
+		assertTrue(layoutMessage
+				.contains("This message contains __ line feeds"));
+	}
+
+	@Test
+	public void test_with_nested_exception() {
+		try {
+			try {
+				throw new IllegalArgumentException("This message contains \r\n line feeds");
+			} catch (IllegalArgumentException ex) {
+				// replace message with line feeds to ensure the message is correctly replaced in first exception
+				throw new RuntimeException("Invalid argument", ex);
+			}
+		} catch (RuntimeException ex) {
+			LOGGER.error("", ex);
+		}
+
+		// Now verify our logging interactions
+		verify(mockAppender).doAppend(captorLoggingEvent.capture());
+
+		// Get the logging event from the captor
+		final LoggingEvent loggingEvent = captorLoggingEvent.getValue();
+
+		// Check log level is correct
+		assertThat(loggingEvent.getLevel(), is(Level.ERROR));
+
+		// Check the message being logged is correct
+		String layoutMessage = encoder.getLayout().doLayout(loggingEvent);
+		assertTrue(layoutMessage
+				.contains("This message contains __ line feeds"));
+	}
+
+}

--- a/owasp-security-logging-logback/src/test/resources/logback-test.xml
+++ b/owasp-security-logging-logback/src/test/resources/logback-test.xml
@@ -3,13 +3,15 @@
 
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>
-            <pattern>STDOUT %d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg %n</pattern>
+            <pattern>STDOUT %d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg %ex %n</pattern>
         </encoder>
     </appender>
 
     <conversionRule conversionWord="crlf"
-                    converterClass="org.owasp.security.logging.mask.CRLFConverter">
-    </conversionRule> />
+                    converterClass="org.owasp.security.logging.mask.CRLFConverter"/>
+
+    <conversionRule conversionWord="ex"
+                    converterClass="org.owasp.security.logging.mask.CRLFThrowableConverter"/>
 
     <conversionRule conversionWord="mask"
                         converterClass="org.owasp.security.logging.mask.MaskingConverter" />
@@ -20,7 +22,7 @@
     <!-- This appender represents a regular application log. -->
     <appender name="APP_CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>
-            <pattern>APP %date [%thread] [%marker] %-5level U:%X{userId} - %crlf(%mask) %n</pattern>
+            <pattern>APP %date [%thread] [%marker] %-5level U:%X{userId} - %crlf(%mask) %ex %n</pattern>
         </encoder>
     </appender>
 
@@ -28,7 +30,7 @@
     <appender name="NOT_CLASSIFIED_CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
         <filter class="org.owasp.security.logging.filter.ExcludeClassifiedMarkerFilter"/>
         <encoder>
-            <pattern>NOT CLASSIFIED %date [%thread] [%marker] %-5level - %msg %n</pattern>
+            <pattern>NOT CLASSIFIED %date [%thread] [%marker] %-5level - %msg %ex %n</pattern>
         </encoder>
     </appender>
     
@@ -51,7 +53,7 @@
             <onMismatch>DENY</onMismatch>
         </filter>
         <encoder>
-            <pattern>CONFIDENTIAL %date [%thread] [%marker] %-5level U:%X{userId} - %crlf(%msg) %n</pattern>
+            <pattern>CONFIDENTIAL %date [%thread] [%marker] %-5level U:%X{userId} - %crlf(%msg) %ex %n</pattern>
         </encoder>
     </appender>
     


### PR DESCRIPTION
PR for Issue #52 
It uses a ThrowableProxyConverter to replace CR & LF in exception messages
With this converter, we need to add in the logback configuration:
```xml
    <conversionRule conversionWord="ex"
                    converterClass="org.owasp.security.logging.mask.CRLFThrowableConverter"/>
```
and then add an `%ex` in the pattern