### PR TITLE
Add a converter that protects agains log forging and xss injection

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -1,0 +1,24 @@
+# This workflow will build a Java project with Maven
+# For more information see: https://help.github.com/actions/language-and-framework-guides/building-and-testing-java-with-maven
+
+name: Java CI with Maven
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up JDK 1.8
+      uses: actions/setup-java@v1
+      with:
+        java-version: 1.8
+    - name: Build with Maven
+      run: mvn -B package --file pom.xml

--- a/owasp-security-logging-common/src/main/java/org/owasp/security/logging/Utils.java
+++ b/owasp-security-logging-common/src/main/java/org/owasp/security/logging/Utils.java
@@ -46,7 +46,7 @@ public class Utils {
 	/**
 	 * Converts an input byte array to a hex encoded String.
 	 *
-	 * @param input
+	 * @param hash
 	 *            Byte array to hex encode
 	 * @return Hex encoded String of the input byte array
 	 */
@@ -83,4 +83,7 @@ public class Utils {
 		return value.replace('\n', '_').replace('\r', '_');
 	}
 
+	public static String escapeAngleBrackets(String value) {
+		return value.replace("<","&lt;").replace(">", "&gt;");
+	}
 }

--- a/owasp-security-logging-common/src/test/java/org/owasp/security/logging/UtilsTest.java
+++ b/owasp-security-logging-common/src/test/java/org/owasp/security/logging/UtilsTest.java
@@ -20,4 +20,9 @@ public class UtilsTest {
         Assert.assertEquals("hello__world", Utils.replaceCRLFWithUnderscore("hello\r\nworld"));
     }
 
+    @Test
+    public void shouldEscapeAngleBrackets() {
+        Assert.assertEquals("&lt;script&gt;", Utils.escapeAngleBrackets("<script>"));
+    }
+
 }

--- a/owasp-security-logging-logback/src/main/java/org/owasp/security/logging/mask/CRLFAndXssConverter.java
+++ b/owasp-security-logging-logback/src/main/java/org/owasp/security/logging/mask/CRLFAndXssConverter.java
@@ -1,0 +1,36 @@
+package org.owasp.security.logging.mask;
+
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.pattern.CompositeConverter;
+import org.owasp.security.logging.Utils;
+
+/**
+ * This converter encodes carriage returns, line feeds and angle brackets to
+ * prevent log forging attacks using new line characters or script execution.
+ *
+ * It is not possible to replace the actual formatted message, instead this
+ * converter returns a masked version of the message that can be accessed using
+ * the conversionWord specified in the conversionRule definition in logback.xml.
+ *
+ * Based on the CRLFConverter by August Detlefsen
+ *
+ * @author Stijn Slaets [stijn.slaets@gmail.com]
+ */
+public class CRLFAndXssConverter extends CompositeConverter<ILoggingEvent> {
+
+    @Override
+    protected String transform(ILoggingEvent event, String in) {
+        String withoutCrlf =  Utils.replaceCRLFWithUnderscore(in);
+        return Utils.escapeAngleBrackets(withoutCrlf);
+    }
+
+    /**
+     * Override start method because the superclass ReplacingCompositeConverter
+     * requires at least two options and this class has none.
+     */
+    @Override
+    public void start() {
+        started = true;
+    }
+
+}

--- a/owasp-security-logging-logback/src/test/java/org/owasp/security/logging/mask/CRLFAndXssConverterTest.java
+++ b/owasp-security-logging-logback/src/test/java/org/owasp/security/logging/mask/CRLFAndXssConverterTest.java
@@ -1,0 +1,108 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.owasp.security.logging.mask;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.verify;
+
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.LoggerContext;
+import ch.qos.logback.classic.PatternLayout;
+import ch.qos.logback.classic.encoder.PatternLayoutEncoder;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.classic.spi.LoggingEvent;
+import ch.qos.logback.core.rolling.RollingFileAppender;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+import org.slf4j.LoggerFactory;
+
+/**
+ *
+ * @author August Detlefsen [augustd@codemagi.com]
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class CRLFAndXssConverterTest {
+
+	LoggerContext loggerContext = (LoggerContext) LoggerFactory
+			.getILoggerFactory();
+
+	Logger LOGGER;
+
+	PatternLayoutEncoder encoder;
+
+
+	@Mock
+	private RollingFileAppender<ILoggingEvent> mockAppender = new RollingFileAppender<ILoggingEvent>();
+
+	// Captor is genericised with ch.qos.logback.classic.spi.LoggingEvent
+	@Captor
+	private ArgumentCaptor<LoggingEvent> captorLoggingEvent;
+
+	@Before
+	public void setUp() {
+		PatternLayout.defaultConverterMap.put("crlfAndXss",
+				CRLFAndXssConverter.class.getName());
+
+		encoder = new PatternLayoutEncoder();
+		encoder.setContext(loggerContext);
+		encoder.setPattern("%-4relative [%thread] %-5level %logger{35} - %crlfAndXss(%msg)%n");
+		encoder.start();
+
+		// Layout layout = new PatternLayout();
+		// layout.setEncoder(encoder);
+
+		mockAppender.setContext(loggerContext);
+		mockAppender.setEncoder(encoder);
+		mockAppender.start();
+
+		LOGGER = (Logger) LoggerFactory.getLogger("CONSOLE");
+		LOGGER.addAppender(mockAppender);
+	}
+
+	@After
+	public void teardown() {
+		LOGGER.detachAppender(mockAppender);
+	}
+
+	@Test
+	public void test() {
+		LOGGER.info("This message contains \r\n line feeds and an htlm tag <script>");
+
+		// Now verify our logging interactions
+		verify(mockAppender).doAppend(captorLoggingEvent.capture());
+
+		// Get the logging event from the captor
+		final LoggingEvent loggingEvent = captorLoggingEvent.getValue();
+
+		// Check log level is correct
+		assertThat(loggingEvent.getLevel(), is(Level.INFO));
+
+		// Check the message being logged is correct
+		// assertThat(loggingEvent.getFormattedMessage(),
+		// is("This message contains __ line feeds"));'
+		String layoutMessage = encoder.getLayout().doLayout(loggingEvent);
+		assertTrue(layoutMessage
+				.contains("This message contains __ line feeds and an htlm tag &lt;script&gt;"));
+	}
+
+}


### PR DESCRIPTION
The existing Logback CRLFConverter protects agains log forging by injecting newline characters in the logs.  However it does not protect agains XSS injection attacks.  This adds a new CRLFAndXSSConverter that escapes angle brackets to prevent the execution of scripts when the logs are processed with a tool that processes html.