### PR TITLE
Add converter for all NLF (newline function) characters

### DIFF
--- a/owasp-security-logging-common/src/main/java/org/owasp/security/logging/Utils.java
+++ b/owasp-security-logging-common/src/main/java/org/owasp/security/logging/Utils.java
@@ -83,4 +83,27 @@ public class Utils {
 		return value.replace('\n', '_').replace('\r', '_');
 	}
 
+	/**
+	 * Replace any NLF (newline function) with an underscore to prevent log injection attacks.
+	 *
+	 * @param value
+	 *            string to convert
+	 * @return converted string
+	 * @see https://unicode.org/versions/Unicode14.0.0/UnicodeStandard-14.0.pdf#page=235
+	 */
+	public static String escapeNLFChars(String value) {
+		return value.replace("\n", "\\n")
+			.replace("\r", "\\r")
+			// NEL
+			.replace("\u0085", "\\u0085")
+			// VT
+			.replace("\u000B", "\\u000B")
+			// FF
+			.replace("\u000C", "\\u000C")
+			// LS
+			.replace("\u2028", "\\u2028")
+			// PS
+			.replace("\u2029", "\\u2029");
+	}
+
 }

--- a/owasp-security-logging-common/src/test/java/org/owasp/security/logging/UtilsTest.java
+++ b/owasp-security-logging-common/src/test/java/org/owasp/security/logging/UtilsTest.java
@@ -5,19 +5,30 @@ import org.junit.Test;
 
 public class UtilsTest {
 
-    @Test
-    public void shouldReplaceCRWithUnderscore() {
-        Assert.assertEquals("hello_world", Utils.replaceCRLFWithUnderscore("hello\rworld"));
-    }
+	@Test
+	public void shouldReplaceCRWithUnderscore() {
+		Assert.assertEquals("hello_world", Utils.replaceCRLFWithUnderscore("hello\rworld"));
+	}
 
-    @Test
-    public void shouldReplaceLFWithUnderscore() {
-        Assert.assertEquals("hello_world", Utils.replaceCRLFWithUnderscore("hello\nworld"));
-    }
+	@Test
+	public void shouldReplaceLFWithUnderscore() {
+		Assert.assertEquals("hello_world", Utils.replaceCRLFWithUnderscore("hello\nworld"));
+	}
 
-    @Test
-    public void shouldReplaceCRLFWithUnderscore() {
-        Assert.assertEquals("hello__world", Utils.replaceCRLFWithUnderscore("hello\r\nworld"));
-    }
+	@Test
+	public void shouldReplaceCRLFWithUnderscore() {
+		Assert.assertEquals("hello__world", Utils.replaceCRLFWithUnderscore("hello\r\nworld"));
+	}
+
+	@Test
+	public void escapeNLFCharsShouldEscapeAllNLF() {
+		Assert.assertEquals("line0\\nline1", Utils.escapeNLFChars("line0\nline1"));
+		Assert.assertEquals("line0\\rline1", Utils.escapeNLFChars("line0\rline1"));
+		Assert.assertEquals("line0\\u0085line1", Utils.escapeNLFChars("line0\u0085line1"));
+		Assert.assertEquals("line0\\u000Bline1", Utils.escapeNLFChars("line0\u000Bline1"));
+		Assert.assertEquals("line0\\u000Cline1", Utils.escapeNLFChars("line0\u000Cline1"));
+		Assert.assertEquals("line0\\u2028line1", Utils.escapeNLFChars("line0\u2028line1"));
+		Assert.assertEquals("line0\\u2029line1", Utils.escapeNLFChars("line0\u2029line1"));
+	}
 
 }

--- a/owasp-security-logging-logback/src/main/java/org/owasp/security/logging/mask/NLFConverter.java
+++ b/owasp-security-logging-logback/src/main/java/org/owasp/security/logging/mask/NLFConverter.java
@@ -1,0 +1,32 @@
+package org.owasp.security.logging.mask;
+
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.pattern.CompositeConverter;
+import org.owasp.security.logging.Utils;
+
+/**
+ * This converter is used to encode any carriage returns and line feeds to
+ * prevent log injection attacks
+ *
+ * It is not possible to replace the actual formatted message, instead this
+ * converter returns a masked version of the message that can be accessed using
+ * the conversionWord specified in the conversionRule definition in logback.xml.
+ * 
+ */
+public class NLFConverter extends CompositeConverter<ILoggingEvent> {
+
+	@Override
+	protected String transform(ILoggingEvent event, String in) {
+		return Utils.escapeNLFChars(in);
+	}
+
+	/**
+	 * Override start method because the superclass ReplacingCompositeConverter
+	 * requires at least two options and this class has none.
+	 */
+	@Override
+	public void start() {
+		started = true;
+	}
+
+}

--- a/owasp-security-logging-logback/src/main/java/org/owasp/security/logging/mask/NLFThrowableConverter.java
+++ b/owasp-security-logging-logback/src/main/java/org/owasp/security/logging/mask/NLFThrowableConverter.java
@@ -1,0 +1,19 @@
+package org.owasp.security.logging.mask;
+
+import ch.qos.logback.classic.pattern.ThrowableProxyConverter;
+import ch.qos.logback.classic.spi.IThrowableProxy;
+
+/**
+ * This converter is used to encode any carriage returns and line feeds to
+ * prevent log injection attacks in exception messages
+ *
+ * This converter uses a NLFThrowableProxy that acts as a proxy to intercept
+ * calls to IThrowable.getMessage to replace the characters in the message
+ */
+public class NLFThrowableConverter extends ThrowableProxyConverter {
+
+	@Override
+	protected String throwableProxyToString(IThrowableProxy tp) {
+		return super.throwableProxyToString(new NLFThrowableProxy(tp));
+	}
+}

--- a/owasp-security-logging-logback/src/main/java/org/owasp/security/logging/mask/NLFThrowableProxy.java
+++ b/owasp-security-logging-logback/src/main/java/org/owasp/security/logging/mask/NLFThrowableProxy.java
@@ -1,0 +1,59 @@
+package org.owasp.security.logging.mask;
+
+import ch.qos.logback.classic.spi.IThrowableProxy;
+import ch.qos.logback.classic.spi.StackTraceElementProxy;
+import org.owasp.security.logging.Utils;
+
+/**
+ * Throwable proxy that replaces NLF (newline function) chars in the message to avoid log injection
+ * in exception messages.
+ * Calls to getMessage are intercepted to replace NLF in the message
+ * Calls to getCause are intercepted to ensure all exceptions in the stack are treated
+ * All other other methods are directly sent through the proxied instance.
+ */
+public class NLFThrowableProxy implements IThrowableProxy {
+	private final IThrowableProxy proxied;
+
+	public NLFThrowableProxy(IThrowableProxy proxied) {
+		this.proxied = proxied;
+	}
+
+	@Override
+	public String getMessage() {
+		if (proxied.getMessage() == null) {
+			return null;
+		}
+		return Utils.replaceCRLFWithUnderscore(proxied.getMessage());
+	}
+
+	@Override
+	public IThrowableProxy getCause() {
+		if (proxied.getCause() == null) {
+			return null;
+		}
+		if (proxied.getCause() == proxied || proxied.getCause() == this) {
+			return this;
+		}
+		return new NLFThrowableProxy(proxied.getCause());
+	}
+
+	@Override
+	public String getClassName() {
+		return proxied.getClassName();
+	}
+
+	@Override
+	public StackTraceElementProxy[] getStackTraceElementProxyArray() {
+		return proxied.getStackTraceElementProxyArray();
+	}
+
+	@Override
+	public int getCommonFrames() {
+		return proxied.getCommonFrames();
+	}
+
+	@Override
+	public IThrowableProxy[] getSuppressed() {
+		return proxied.getSuppressed();
+	}
+}


### PR DESCRIPTION
New classes have been added to keep backwards compitability. Otherwise replaceCRLFWithUnderscore would have to be renamed. 
See https://unicode.org/versions/Unicode14.0.0/UnicodeStandard-14.0.pdf#page=235

Fixes #59 