### PR TITLE
Resolves #71 - Updates the logback version

### DIFF
--- a/owasp-security-logging-log4j/pom.xml
+++ b/owasp-security-logging-log4j/pom.xml
@@ -31,8 +31,19 @@
     <url>https://github.com/javabeanz/owasp-security-logging</url>
   </scm>
   <properties>
-    <log4j.version>2.16.0</log4j.version>
+    <log4j2.version>2.16.0</log4j2.version>
   </properties>
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>org.apache.logging.log4j</groupId>
+        <artifactId>log4j-bom</artifactId>
+        <version>${log4j2.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
   <dependencies>
     <dependency>
       <groupId>org.owasp</groupId>
@@ -46,17 +57,14 @@
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-slf4j-impl</artifactId>
-      <version>${log4j.version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-core</artifactId>
-      <version>${log4j.version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-api</artifactId>
-      <version>${log4j.version}</version>
     </dependency>
     <dependency>
       <groupId>junit</groupId>
@@ -71,7 +79,7 @@
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-core</artifactId>
-      <version>${log4j.version}</version>
+      <version>${log4j2.version}</version>
       <type>test-jar</type>
       <scope>test</scope>
     </dependency>

--- a/owasp-security-logging-logback/pom.xml
+++ b/owasp-security-logging-logback/pom.xml
@@ -30,6 +30,9 @@
     <developerConnection>scm:git:git@github.com:javabeanz/owasp-security-logging.git</developerConnection>
     <url>https://github.com/javabeanz/owasp-security-logging</url>
   </scm>
+  <properties>
+    <logback.version>1.2.8</logback.version>
+  </properties>
   <dependencies>
     <dependency>
       <groupId>org.owasp</groupId>
@@ -59,12 +62,12 @@
     <dependency>
       <groupId>ch.qos.logback</groupId>
       <artifactId>logback-classic</artifactId>
-      <version>1.2.0</version>
+      <version>${logback.version}</version>
     </dependency>
     <dependency>
       <groupId>ch.qos.logback</groupId>
       <artifactId>logback-core</artifactId>
-      <version>1.2.0</version>
+      <version>${logback.version}</version>
     </dependency>
     <dependency>
       <groupId>commons-codec</groupId>


### PR DESCRIPTION
Resolves #71

Updates the logback version

The details can be found at:

http://slf4j.org/log4shell.html

The key details are these lines:

However, logback may make JNDI calls from within its configuration file. This was recently reported in LOGBACK-1591 as a vulnerability of lesser severity. In response, we have released logback version 1.2.8. Please upgrade.